### PR TITLE
fix field names that are C++ keywords

### DIFF
--- a/protobuf-c-iter-unpack.py
+++ b/protobuf-c-iter-unpack.py
@@ -331,6 +331,18 @@ class _base(object):
   (types which use the varint, 32-bit, or 64-bit wire types) can be declared "packed".
   """
   repeated_init_size = 4
+  keywords = set([
+    "and", "and_eq", "asm", "auto", "bitand", "bitor", "bool", "break", "case",
+    "catch", "char", "class", "compl", "const", "const_cast", "continue",
+    "default", "delete", "do", "double", "dynamic_cast", "else", "enum",
+    "explicit", "extern", "false", "float", "for", "friend", "goto", "if",
+    "inline", "int", "long", "mutable", "namespace", "new", "not", "not_eq",
+    "operator", "or", "or_eq", "private", "protected", "public", "register",
+    "reinterpret_cast", "return", "short", "signed", "sizeof", "static",
+    "static_cast", "struct", "switch", "template", "this", "throw", "true", "try",
+    "typedef", "typeid", "typename", "union", "unsigned", "using", "virtual",
+    "void", "volatile", "wchar_t", "while", "xor", "xor_eq"
+  ])
 
   def __init__(self, protobuf_field):
     self._field = protobuf_field
@@ -382,7 +394,12 @@ class _base(object):
     ]
 
   def name(self):
-    return self._field.name.lower()
+    name = self._field.name.lower()
+
+    if name in self.keywords:
+        return name + '_'
+
+    return name
 
   def repeated_check_resize(self):
     if not self.is_repeated():


### PR DESCRIPTION
protoc-c compiler adds an underscore to field names that are C++ keywords. Python compiler doesn't do that, so names in the code generated by iter-unpack and protoc-c can be different (e.g object->new and object->new_).